### PR TITLE
Guarding against Babel6's toplevel undefined

### DIFF
--- a/jsxdom.js
+++ b/jsxdom.js
@@ -44,4 +44,4 @@ tags.forEach(function(tag) {
 });
 
 global.JSXDOM = JSXDOM;
-})(this);
+})(this || window || global);


### PR DESCRIPTION
Usually, when this is ran through babel,

```
(function(global){
    // ...
})(this)
```

actually becomes

```
(function(global){
    // ...
})(undefined) // <---
```

And that sucks!

Using the `or` operator allows us to "select" the proper global value. In NodeJS, that is `global` - in the browser, that is `window`.
